### PR TITLE
Added Bitwig Performance Twister

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ https://github.com/bitwig/bitwig-extensions
 | Maschine Jam | MonsterJam by Minortom | https://github.com/unthingable/monster-jam/ | [KVR Thread](https://www.kvraudio.com/forum/viewtopic.php?t=566800) |
 | Maschine Mikro Controller | Maschine Mikro Controller | https://github.com/ericahrens/MaschineMikroBitWig | |
 | MidiFighter Twister | Twister Sister By Dozius | https://github.com/dozius/TwisterSister/tree/main | [KVR Thread](https://www.kvraudio.com/forum/viewtopic.php?t=562511) |
+| MidiFighter Twister | Bitwig Performance Twister | https://github.com/Markram71/Bitwig-Performance-Twister | [KVR Thread](https://www.kvraudio.com/forum/viewtopic.php?t=605243) |
 
 
 


### PR DESCRIPTION
I have created a new controller extension for the Midi Fighter Twister by DJ Techtools. It's a new extension with six different modes, many feature (e.g. a controller for an EQ+ device) including an user documentation.